### PR TITLE
Update udap.fhirserver.devdays.csproj

### DIFF
--- a/udap.fhirserver.devdays/udap.fhirserver.devdays.csproj
+++ b/udap.fhirserver.devdays/udap.fhirserver.devdays.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="brianpos.Fhir.R4B.WebApi.AspNetCore" Version="5.3.0-beta2" />
     <PackageReference Include="Hl7.Fhir.Specification.R4B" Version="5.3.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.3" />
+    <PackageReference Include="Microsoft.IdentityModel.Protocols.OpenIdConnect" Version="7.5.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.1" />
     <PackageReference Include="Udap.Metadata.Server" Version="0.3.31" />
   </ItemGroup>


### PR DESCRIPTION
Need the OpeIdConnect package so that the jwks_uri is fetched.  Something has changed and since the Microsoft.AspNetCore.Authentication.JwtBearer package was updated to 8.0.3 it seems.  It is not something you catch at static compile time.